### PR TITLE
#25 DBに保持されているコメントをChatGPTの会話履歴に保持する

### DIFF
--- a/webapp/src/main/java/org/ymmy/todo_chat/service/Assistant.java
+++ b/webapp/src/main/java/org/ymmy/todo_chat/service/Assistant.java
@@ -1,0 +1,11 @@
+package org.ymmy.todo_chat.service;
+
+import dev.langchain4j.service.MemoryId;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+
+public interface Assistant {
+
+  @SystemMessage("You are a polite assistant in the Todo × chat app")
+  String chat(@MemoryId final Long memoryId, @UserMessage final String userMessage);
+}

--- a/webapp/src/main/java/org/ymmy/todo_chat/service/LangChain4jService.java
+++ b/webapp/src/main/java/org/ymmy/todo_chat/service/LangChain4jService.java
@@ -1,26 +1,49 @@
 package org.ymmy.todo_chat.service;
 
-import dev.langchain4j.data.message.TextContent;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.data.message.ChatMessage;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.memory.chat.MessageWindowChatMemory;
 import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.service.AiServices;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.ymmy.todo_chat.db.entity.Comment;
 import org.ymmy.todo_chat.model.dto.CommentDto;
+import org.ymmy.todo_chat.repository.CommentRepository;
 
 @Service
 public class LangChain4jService {
 
-  private final ChatLanguageModel chatLanguageModel;
+  private final Assistant assistant;
+
+  private final CommentRepository commentRepository;
 
   public LangChain4jService(
       @Value("${openai.apikey}") final String apiKey, //
-      @Value("${openai.model}") final String model
+      @Value("${openai.model}") final String model,
+      final CommentRepository commentRepository
   ) {
-    this.chatLanguageModel = OpenAiChatModel.builder() //
+
+    this.commentRepository = commentRepository;
+
+    final var chatLanguageModel = OpenAiChatModel.builder() //
         .apiKey(apiKey) //
         .modelName(model) //
         .build();
+    this.assistant = AiServices.builder(Assistant.class) //
+        .chatLanguageModel(chatLanguageModel) //
+        .chatMemoryProvider(this::initializeChatMemory) //
+        .build();
+  }
+
+  private MessageWindowChatMemory initializeChatMemory(final Object memoryId) {
+    final var commentList = commentRepository.selectByThreadId((Long) memoryId);
+    final var chatMemory = MessageWindowChatMemory.withMaxMessages(20);
+
+    commentList.forEach(comment -> chatMemory.add(getChatMessage(comment)));
+
+    return chatMemory;
   }
 
   /**
@@ -30,10 +53,13 @@ public class LangChain4jService {
    * @return 返答内容
    */
   public String getResponse(final CommentDto commentDto) {
-    final var reply = chatLanguageModel.generate( //
-        UserMessage.from(TextContent.from(commentDto.getComment()))
-    );
+    return assistant.chat(commentDto.getThreadId(), commentDto.getComment());
+  }
 
-    return reply.content().text();
+  private ChatMessage getChatMessage(final Comment comment) {
+    if (comment.getCreatedBy() == 0) {
+      return AiMessage.aiMessage(comment.getComment());
+    }
+    return UserMessage.userMessage(comment.getComment());
   }
 }


### PR DESCRIPTION
## 内容
- 過去の会話履歴をDBから取得して保持するように実装
- また、保持できる会話の上限を20に設定
- 会話はユーザー毎（スレッド毎）に別々に保持するように実装