### PR TITLE
#41 Appからのコメント返信待ち時、ユーザーがコメントを送信できる

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -53,10 +53,14 @@
   </build>
 
   <dependencies>
-    <!-- Spring Boot Starter Web -->
     <dependency>
       <artifactId>spring-boot-starter</artifactId>
       <groupId>org.springframework.boot</groupId>
+    </dependency>
+    <!-- Spring Boot Starter Web -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
     </dependency>
     <!-- Spring Boot Starter Security -->
     <dependency>

--- a/webapp/src/main/resources/static/js/message.js
+++ b/webapp/src/main/resources/static/js/message.js
@@ -7,6 +7,7 @@ $("#sendCommentForm").on("submit", function(event) {
 
     createComment({ comment: comment, createdBy: threadId, createdAt: new Date(), status: 200 });
     $("#comment").val("");
+    $("#sendBtn").prop("disabled", true);
 
     fetch('/comment/send', {
       method: 'POST',
@@ -17,8 +18,14 @@ $("#sendCommentForm").on("submit", function(event) {
       body: JSON.stringify({ comment, threadId })
     })
     .then(response => response.json())
-    .then(comment => createComment(comment))
-    .catch(error => console.error('Error:', error));
+    .then(comment => {
+      $("#sendBtn").prop("disabled", false);
+      createComment(comment);
+    })
+    .catch(error => {
+      $("#sendBtn").prop("disabled", false);
+      console.error('Error:', error);
+    });
   }
 });
 

--- a/webapp/src/main/resources/templates/fragments/message.html
+++ b/webapp/src/main/resources/templates/fragments/message.html
@@ -52,7 +52,7 @@
       <div class="w-100">
         <form class="d-flex" th:action="@{/comment/send}" method="post" id="sendCommentForm">
           <textarea name="comment" id="comment" class="form-control" rows="1" style="max-height: 10vh;"></textarea>
-          <button type="submit" class="btn btn-primary ms-2">
+          <button type="submit" class="btn btn-primary ms-2" id="sendBtn">
             <svg class="bi d-block" width="16" height="16" fill="currentColor">
               <use xlink:href="#send"></use>
             </svg>


### PR DESCRIPTION
# 内容
- 返信待ちの間は送信ボタンを非活性にする
- pom.xmlに`spring-boot-starter-web`を追加